### PR TITLE
Added support for GitHub updater plugin

### DIFF
--- a/custom-site-icon-sizes.php
+++ b/custom-site-icon-sizes.php
@@ -1,11 +1,12 @@
 <?php
     defined( 'ABSPATH' ) or die( "Nothing to see!" );
 /**
- * Plugin Name: Custom site icon sizes
- * Description: Custom site icon sizes
- * Version: 1.0
- * Author: Florian Brinkmann
- * Author URI: http://florianbrinkmann.de
+ * Plugin Name:       Custom site icon sizes
+ * Description:       Custom site icon sizes
+ * Version:           1.0
+ * Author:            Florian Brinkmann
+ * Author URI:        http://florianbrinkmann.de
+ * GitHub Plugin URI: https://github.com/FlorianBrinkmann/custom-site-icon-sizes
  */
 function csiz_custom_site_icon_size( $sizes ) {
     array_push( $sizes, 57, 60, 72, 76, 114, 120, 144, 152, 96, 16 );


### PR DESCRIPTION
Added 1 line to file header in order to support Andy Fragen’s [GitHub Updater plugin](https://github.com/afragen/github-updater). 

Thus users of the updater plugin would be able to update your plugin from their WordPress back-end. Other users who don’t use the GitHub updater wouldn’t notice anything.
